### PR TITLE
Database suffix generator

### DIFF
--- a/src/Core/LocalDb.cs
+++ b/src/Core/LocalDb.cs
@@ -57,15 +57,18 @@ namespace RimDev.Automation.Sql
 
         public string Location { get; protected set; }
 
-        public LocalDb(string databaseName = null, string version = Versions.V11, string location = null, string databasePrefix = "localdb")
+        public Func<string> DatabaseSuffixGenerator { get; protected set; } 
+
+        public LocalDb(string databaseName = null, string version = Versions.V11, string location = null, string databasePrefix = "localdb", Func<string> databaseSuffixGenerator = null)
         {
             if (!Versions.IsValid(version))
                 throw new ArgumentOutOfRangeException("version", Version, "is not a supported version of localdb on your local machine");
 
             Location = location;
             Version = version;
+            DatabaseSuffixGenerator = databaseSuffixGenerator ?? DateTime.Now.Ticks.ToString;
             DatabaseName = string.IsNullOrWhiteSpace(databaseName)
-                ? string.Format("{0}_{1}", databasePrefix, DateTime.Now.Ticks)
+                ? string.Format("{0}_{1}", databasePrefix, DatabaseSuffixGenerator())
                 : databaseName;
 
             CreateDatabase();

--- a/tests/Core.Tests/LocalDbTests.cs
+++ b/tests/Core.Tests/LocalDbTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using RimDev.Automation.Sql;
 using Xunit;
 
@@ -55,6 +56,17 @@ namespace RimDev.Automation.Core
             using (var db = new LocalDb())
             {
                 Assert.Equal(LocalDb.Versions.V11, db.Version);
+            }
+        }
+
+        [Fact]
+        public void LocalDb_set_databaseSuffixGenerator()
+        {
+            var guid = Guid.NewGuid().ToString("N");
+            using (var db = new LocalDb(databaseSuffixGenerator: () => guid ))
+            {
+                Assert.Contains(guid, db.DatabaseName);
+                Debug.WriteLine(db.DatabaseName);
             }
         }
     }


### PR DESCRIPTION
The default suffix generator uses DateTime.Now.Ticks, this is normally
ok, until you run in parallel with a unit test runner that decides
to put all the localdb files in the same directory. This can cause an
overlap that leads to test failures.

The suffix generator allows you to inject a unique suffix based on any
generator you can think of: Guid, DateTime, etc.

#16