### PR TITLE
clean up db async to improve perf on long test runs

### DIFF
--- a/src/Core/LocalDb.cs
+++ b/src/Core/LocalDb.cs
@@ -5,8 +5,8 @@ using System.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.Win32;
-
 
 namespace RimDev.Automation.Sql
 {
@@ -166,7 +166,7 @@ namespace RimDev.Automation.Sql
 
         public void Dispose()
         {
-            DetachDatabase();
+            Task.Run(() => DetachDatabase());
         }
     }
 }


### PR DESCRIPTION
We're doing this on our local project and it's saving as much as 3s per test run and much more when many tests are run and lowering our CI build times.