### PR TITLE
Split Version into real version and instance name

### DIFF
--- a/src/Core/LocalDb.cs
+++ b/src/Core/LocalDb.cs
@@ -86,7 +86,7 @@ namespace RimDev.Automation.Sql
             DatabaseName = string.IsNullOrWhiteSpace(databaseName)
                 ? string.Format("{0}_{1}", databasePrefix, DatabaseSuffixGenerator())
                 : databaseName;
-            InstanceName = instanceName ?? string.Format("v{0}", Version);
+            InstanceName = instanceName.ToLower() ?? string.Format("v{0}", Version); //sqllocaldb.exe always uses lower case
 
             if (tryInstallingInstanceIfNotExists && !InstallLocalDbInstanceIfNotExists())
                 throw new ApplicationException($"Could not start instance {InstanceName} of localDb with version {Version}");

--- a/src/Core/LocalDb.cs
+++ b/src/Core/LocalDb.cs
@@ -86,7 +86,7 @@ namespace RimDev.Automation.Sql
             DatabaseName = string.IsNullOrWhiteSpace(databaseName)
                 ? string.Format("{0}_{1}", databasePrefix, DatabaseSuffixGenerator())
                 : databaseName;
-            InstanceName = instanceName.ToLower() ?? string.Format("v{0}", Version); //sqllocaldb.exe always uses lower case
+            InstanceName = instanceName?.ToLower() ?? string.Format("v{0}", Version); //sqllocaldb.exe always uses lower case
 
             if (tryInstallingInstanceIfNotExists && !InstallLocalDbInstanceIfNotExists())
                 throw new ApplicationException($"Could not start instance {InstanceName} of localDb with version {Version}");

--- a/src/Core/LocalDb.cs
+++ b/src/Core/LocalDb.cs
@@ -73,20 +73,20 @@ namespace RimDev.Automation.Sql
             int? connectionTimeout = null,
             bool multipleActiveResultSets = false,
             bool tryInstallingInstanceIfNotExists = false,
-            string instanceName = "v" + Versions.V11)
+            string instanceName = null)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 throw new PlatformNotSupportedException("LocalDb only works on Windows platform");
 
             Location = location;
-            Version = version;
+            Version = version.Replace("v", ""); //Try to stay backwards compatible by removing "v" to get the real version number
             DatabaseSuffixGenerator = databaseSuffixGenerator ?? DateTime.Now.Ticks.ToString;
             ConnectionTimeout = connectionTimeout;
             MultipleActiveResultsSets = multipleActiveResultSets;
             DatabaseName = string.IsNullOrWhiteSpace(databaseName)
                 ? string.Format("{0}_{1}", databasePrefix, DatabaseSuffixGenerator())
                 : databaseName;
-            InstanceName = instanceName;
+            InstanceName = instanceName ?? string.Format("v{0}", Version);
 
             if (tryInstallingInstanceIfNotExists && !InstallLocalDbInstanceIfNotExists())
                 throw new ApplicationException($"Could not start instance {InstanceName} of localDb with version {Version}");

--- a/src/Core/LocalDb.cs
+++ b/src/Core/LocalDb.cs
@@ -167,6 +167,7 @@ namespace RimDev.Automation.Sql
                 standardOutput.Append(process.StandardOutput.ReadToEnd());
                 standardError.Append(process.StandardError.ReadToEnd());
             }
+            Console.WriteLine(standardOutput.ToString());
 
             var error = standardError.ToString();
             if (!string.IsNullOrEmpty(error))
@@ -194,6 +195,7 @@ namespace RimDev.Automation.Sql
                     standardOutput.Append(process.StandardOutput.ReadToEnd());
                     standardError.Append(process.StandardError.ReadToEnd());
                 }
+                Console.WriteLine(standardOutput.ToString());
 
                 error = standardError.ToString();
                 if (!string.IsNullOrEmpty(error))

--- a/tests/Core.Tests/LocalDbTests.cs
+++ b/tests/Core.Tests/LocalDbTests.cs
@@ -19,7 +19,7 @@ namespace RimDev.Automation.Core
         [Fact]
         public void Can_CreateLocalDB_With_V11_And_InstanceName()
         {
-            using (var db = new LocalDb(version: LocalDb.Versions.V11, instanceName: "Test"))
+            using (var db = new LocalDb(version: LocalDb.Versions.V11, instanceName: "Test", tryInstallingInstanceIfNotExists: true))
             {
                 Assert.NotNull(db);
             }
@@ -37,7 +37,7 @@ namespace RimDev.Automation.Core
         [Fact]
         public void Can_CreateLocalDB_With_V12_And_InstanceName()
         {
-            using (var db = new LocalDb(version: LocalDb.Versions.V12, instanceName: "Test"))
+            using (var db = new LocalDb(version: LocalDb.Versions.V12, instanceName: "Test", tryInstallingInstanceIfNotExists: true))
             {
                 Assert.NotNull(db);
             }
@@ -55,7 +55,7 @@ namespace RimDev.Automation.Core
         [Fact]
         public void Can_CreateLocalDB_With_V13_And_InstanceName()
         {
-            using (var db = new LocalDb(version: LocalDb.Versions.V13, instanceName: "Test"))
+            using (var db = new LocalDb(version: LocalDb.Versions.V13, instanceName: "Test", tryInstallingInstanceIfNotExists: true))
             {
                 Assert.NotNull(db);
             }

--- a/tests/Core.Tests/LocalDbTests.cs
+++ b/tests/Core.Tests/LocalDbTests.cs
@@ -17,6 +17,15 @@ namespace RimDev.Automation.Core
         }
 
         [Fact]
+        public void Can_CreateLocalDB_With_V11_And_InstanceName()
+        {
+            using (var db = new LocalDb(version: LocalDb.Versions.V11, instanceName: "Test"))
+            {
+                Assert.NotNull(db);
+            }
+        }
+
+        [Fact]
         public void Can_CreateLocalDB_With_V12()
         {
             using (var db = new LocalDb(version: LocalDb.Versions.V12))
@@ -26,9 +35,27 @@ namespace RimDev.Automation.Core
         }
 
         [Fact]
+        public void Can_CreateLocalDB_With_V12_And_InstanceName()
+        {
+            using (var db = new LocalDb(version: LocalDb.Versions.V12, instanceName: "Test"))
+            {
+                Assert.NotNull(db);
+            }
+        }
+
+        [Fact]
         public void Can_CreateLocalDB_With_V13()
         {
             using (var db = new LocalDb(version: LocalDb.Versions.V13))
+            {
+                Assert.NotNull(db);
+            }
+        }
+
+        [Fact]
+        public void Can_CreateLocalDB_With_V13_And_InstanceName()
+        {
+            using (var db = new LocalDb(version: LocalDb.Versions.V13, instanceName: "Test"))
             {
                 Assert.NotNull(db);
             }
@@ -56,6 +83,15 @@ namespace RimDev.Automation.Core
             using (var db = new LocalDb())
             {
                 Assert.Equal(LocalDb.Versions.V11, db.Version);
+            }
+        }
+
+        [Fact]
+        public void LocalDb_InstanceName_defaults_to_V11()
+        {
+            using (var db = new LocalDb())
+            {
+                Assert.Equal("v" + LocalDb.Versions.V11, db.InstanceName);
             }
         }
 


### PR DESCRIPTION
Remove "v" from ```Versions``` and add ```InstanceName```. ```InstanceName``` is used everywhere except when creating an instance.

I have added```instanceName``` as the last parameter in the constructor to avoid breaking unnamed parameters (```db = new LocalDb("test", "v12")``` etc.). Named parameters (fx. ```db = new LocalDb(version: "v12")``` works as well. In all cases "v" is automatically removed if given as part of ```version``` to stay backwards compatible.

Solves #55 